### PR TITLE
Add Injection from SwiftUI to global Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To install using Xcode's Swift Package Manager, follow these steps:
 
 - Go to **File > Swift Package > Add Package Dependency**
 - Enter the URL: **<https://github.com/hainayanda/SwiftEnvironment.git>**
-- Choose **Up to Next Major** for the version rule and set the version to **2.4.0**.
+- Choose **Up to Next Major** for the version rule and set the version to **3.0.1**.
 - Click "Next" and wait for the package to be fetched.
 
 ### Swift Package Manager (Package.swift)
@@ -34,7 +34,7 @@ If you prefer using Package.swift, add SwiftEnvironment as a dependency in your 
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/hainayanda/SwiftEnvironment.git", .upToNextMajor(from: "3.0.0"))
+    .package(url: "https://github.com/hainayanda/SwiftEnvironment.git", .upToNextMajor(from: "3.0.1"))
 ]
 ```
 

--- a/Sources/SwiftEnvironment/Extensions/SwiftUIEnvironment+Extensions.swift
+++ b/Sources/SwiftEnvironment/Extensions/SwiftUIEnvironment+Extensions.swift
@@ -8,13 +8,33 @@
 import SwiftUI
 
 public extension Scene {
-    func defaultEnvironment<V>(_ keyPath: WritableKeyPath<EnvironmentValues, V>, from source: SwiftEnvironmentValues) -> some Scene {
+    nonisolated func defaultEnvironment<V>(_ keyPath: WritableKeyPath<EnvironmentValues, V>, from source: SwiftEnvironmentValues) -> some Scene {
         environment(keyPath, source[dynamicMember: keyPath])
+    }
+    
+    nonisolated func environment<V>(_ keyPath: WritableKeyPath<EnvironmentValues, V>, _ value: V, injectTo source: SwiftEnvironmentValues) -> some Scene {
+        source.environment(keyPath, value)
+        return environment(keyPath, value)
+    }
+    
+    nonisolated func weakEnvironment<V>(_ keyPath: WritableKeyPath<EnvironmentValues, V>, _ value: V, injectTo source: SwiftEnvironmentValues) -> some Scene {
+        source.weak(keyPath, value)
+        return environment(keyPath, value)
     }
 }
 
 public extension View {
-    func defaultEnvironment<V>(_ keyPath: WritableKeyPath<EnvironmentValues, V>, from source: SwiftEnvironmentValues) -> some View {
+    nonisolated func defaultEnvironment<V>(_ keyPath: WritableKeyPath<EnvironmentValues, V>, from source: SwiftEnvironmentValues) -> some View {
         environment(keyPath, source[dynamicMember: keyPath])
+    }
+    
+    nonisolated func environment<V>(_ keyPath: WritableKeyPath<EnvironmentValues, V>, _ value: V, injectTo source: SwiftEnvironmentValues) -> some View {
+        source.environment(keyPath, value)
+        return environment(keyPath, value)
+    }
+    
+    nonisolated func weakEnvironment<V>(_ keyPath: WritableKeyPath<EnvironmentValues, V>, _ value: V, injectTo source: SwiftEnvironmentValues) -> some View {
+        source.weak(keyPath, value)
+        return environment(keyPath, value)
     }
 }

--- a/Sources/SwiftEnvironment/GlobalEnvironment/GlobalEnvironment.swift
+++ b/Sources/SwiftEnvironment/GlobalEnvironment/GlobalEnvironment.swift
@@ -42,6 +42,5 @@ public final class GlobalEnvironment<Value>: DynamicProperty, PropertyWrapperDis
             .map { $0.1.id }
             .weakAssign(to: \.lastAssignmentId, on: self)
             .store(in: &cancellables)
-            
     }
 }


### PR DESCRIPTION
This pull request introduces new methods to enhance the handling of environment values in SwiftUI extensions and includes a minor cleanup in the `GlobalEnvironment` class. The key updates focus on adding flexibility for injecting and managing environment values.

### Enhancements to SwiftUI Environment Extensions:

* [`Sources/SwiftEnvironment/Extensions/SwiftUIEnvironment+Extensions.swift`](diffhunk://#diff-21d15fa3af42a6528f619816621817974f2af66672c874f755ecab7568f2e150L11-R39): Added three new `nonisolated` methods (`environment`, `weakEnvironment`, and an updated `defaultEnvironment`) for both `Scene` and `View` extensions. These methods allow injecting and managing environment values more effectively, including support for weak references.

### Code Cleanup:

* [`Sources/SwiftEnvironment/GlobalEnvironment/GlobalEnvironment.swift`](diffhunk://#diff-392bb8333de21da798f35eba3df3947103a1c4b403030668c80953758c9c35bfL45): Removed an unnecessary blank line in the `GlobalEnvironment` class for improved code clarity.