### PR TITLE
Fix some deadlock issue

### DIFF
--- a/Sources/SwiftEnvironment/Environment/GlobalEnvironment.swift
+++ b/Sources/SwiftEnvironment/Environment/GlobalEnvironment.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import Combine
-import SwiftUICore
+import SwiftUI
 
 @propertyWrapper
 public final class GlobalEnvironment<Value>: DynamicProperty, PropertyWrapperDiscardable {

--- a/Sources/SwiftEnvironment/Environment/GlobalValues.swift
+++ b/Sources/SwiftEnvironment/Environment/GlobalValues.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import SwiftUICore
 import Combine
 import Chary
 

--- a/Sources/SwiftEnvironment/Environment/GlobalValues.swift
+++ b/Sources/SwiftEnvironment/Environment/GlobalValues.swift
@@ -70,11 +70,11 @@ public struct GlobalValues: @unchecked Sendable {
     
     @discardableResult
     public static func use<Source, Value>(
-        _ soureKeyPath: KeyPath<GlobalValues, Source>,
+        _ sourceKeyPath: KeyPath<GlobalValues, Source>,
         for keyPath: KeyPath<GlobalValues, Value>) -> GlobalValues.Type {
             assign(
                 resolver: OptionalTransientInstanceResolver<Value>(queue: nil) {
-                    return GlobalValues.underlyingResolvers[soureKeyPath]?.resolve(for: Value.self)
+                    return GlobalValues.underlyingResolvers[sourceKeyPath]?.resolve(for: Value.self)
                 },
                 to: keyPath
             )
@@ -122,23 +122,23 @@ public extension GlobalValues {
     @inlinable
     @discardableResult
     static func use<Source, Value1, Value2>(
-        _ soureKeyPath: KeyPath<GlobalValues, Source>,
+        _ sourceKeyPath: KeyPath<GlobalValues, Source>,
         for keyPath1: KeyPath<GlobalValues, Value1>,
         _ keyPath2: KeyPath<GlobalValues, Value2>) -> GlobalValues.Type {
-            use(soureKeyPath, for: keyPath1)
-                .use(soureKeyPath, for: keyPath2)
+            use(sourceKeyPath, for: keyPath1)
+                .use(sourceKeyPath, for: keyPath2)
         }
     
     @inlinable
     @discardableResult
     static func use<Source, Value1, Value2, Value3>(
-        _ soureKeyPath: KeyPath<GlobalValues, Source>,
+        _ sourceKeyPath: KeyPath<GlobalValues, Source>,
         for keyPath1: KeyPath<GlobalValues, Value1>,
         _ keyPath2: KeyPath<GlobalValues, Value2>,
         _ keyPath3: KeyPath<GlobalValues, Value3>) -> GlobalValues.Type {
-            use(soureKeyPath, for: keyPath1)
-                .use(soureKeyPath, for: keyPath2)
-                .use(soureKeyPath, for: keyPath3)
+            use(sourceKeyPath, for: keyPath1)
+                .use(sourceKeyPath, for: keyPath2)
+                .use(sourceKeyPath, for: keyPath3)
         }
 }
 

--- a/Sources/SwiftEnvironment/InstanceResolver/InstanceResolver.swift
+++ b/Sources/SwiftEnvironment/InstanceResolver/InstanceResolver.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import SwiftUI
 
 public protocol InstanceResolver {
     var id: UUID { get }

--- a/Sources/SwiftEnvironment/InstanceResolver/OptionalTransientInstanceResolver.swift
+++ b/Sources/SwiftEnvironment/InstanceResolver/OptionalTransientInstanceResolver.swift
@@ -1,20 +1,20 @@
 //
-//  TransientInstanceResolver.swift
+//  OptionalTransientInstanceResolver.swift
 //  SwiftEnvironment
 //
-//  Created by Nayanda Haberty on 5/11/24.
+//  Created by Nayanda Haberty on 01/06/25.
 //
 
 import Foundation
 import Chary
 import SwiftUI
 
-struct TransientInstanceResolver<Value>: InstanceResolver {
+struct OptionalTransientInstanceResolver<Value>: InstanceResolver {
     let id: UUID = UUID()
-    private let resolver: () -> Value
+    private let resolver: () -> Value?
     private let queue: DispatchQueue?
     
-    @inlinable init(queue: DispatchQueue?, resolver: @escaping () -> Value) {
+    @inlinable init(queue: DispatchQueue?, resolver: @escaping () -> Value?) {
         self.resolver = resolver
         self.queue = queue
     }

--- a/Sources/SwiftEnvironment/InstanceResolver/OptionalTransientInstanceResolver.swift
+++ b/Sources/SwiftEnvironment/InstanceResolver/OptionalTransientInstanceResolver.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import Chary
-import SwiftUI
 
 struct OptionalTransientInstanceResolver<Value>: InstanceResolver {
     let id: UUID = UUID()

--- a/Sources/SwiftEnvironment/InstanceResolver/OptionalTransientInstanceResolver.swift
+++ b/Sources/SwiftEnvironment/InstanceResolver/OptionalTransientInstanceResolver.swift
@@ -20,9 +20,6 @@ struct OptionalTransientInstanceResolver<Value>: InstanceResolver {
     
     @inlinable func resolve<V>(for type: V.Type) -> V? {
         let instance = queue?.safeSync(execute: resolver) ?? resolver()
-        guard let kInstance = instance as? V else {
-            return nil
-        }
-        return kInstance
+        return instance as? V
     }
 }

--- a/Sources/SwiftEnvironment/InstanceResolver/SingletonInstanceResolver.swift
+++ b/Sources/SwiftEnvironment/InstanceResolver/SingletonInstanceResolver.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import SwiftUI
 
 final class SingletonInstanceResolver<Value>: InstanceResolver {
     let id: UUID = UUID()

--- a/Sources/SwiftEnvironment/InstanceResolver/TransientInstanceResolver.swift
+++ b/Sources/SwiftEnvironment/InstanceResolver/TransientInstanceResolver.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import Chary
-import SwiftUI
 
 struct TransientInstanceResolver<Value>: InstanceResolver {
     let id: UUID = UUID()

--- a/Sources/SwiftEnvironment/InstanceResolver/TransientInstanceResolver.swift
+++ b/Sources/SwiftEnvironment/InstanceResolver/TransientInstanceResolver.swift
@@ -27,3 +27,24 @@ struct TransientInstanceResolver<Value>: InstanceResolver {
         return kInstance
     }
 }
+
+struct OptionalTransientInstanceResolver<Value>: InstanceResolver {
+    let id: UUID = UUID()
+    private let resolver: () -> Value?
+    private let queue: DispatchQueue?
+    
+    @inlinable init(queue: DispatchQueue?, resolver: @escaping () -> Value?) {
+        self.resolver = resolver
+        self.queue = queue
+    }
+    
+    @inlinable func resolve<V>(for type: V.Type) -> V? {
+        let instance = queue?.safeSync(execute: resolver) ?? resolver()
+        guard let kInstance = instance as? V else {
+            return nil
+        }
+        return kInstance
+    }
+}
+
+

--- a/Sources/SwiftEnvironment/InstanceResolver/WeakInstanceResolver.swift
+++ b/Sources/SwiftEnvironment/InstanceResolver/WeakInstanceResolver.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import Chary
-import SwiftUI
 
 final class WeakInstanceResolver<Value>: InstanceResolver {
     let id: UUID = UUID()

--- a/Sources/SwiftEnvironment/Macros.swift
+++ b/Sources/SwiftEnvironment/Macros.swift
@@ -5,7 +5,10 @@
 //  Created by Nayanda Haberty on 31/05/25.
 //
 
+import Foundation
+
 @attached(accessor)
+@attached(peer, names: prefixed(___))
 public macro GlobalEntry() = #externalMacro(
     module: "SwiftEnvironmentMacro", type: "GlobalEntryMacro"
 )

--- a/Sources/SwiftEnvironmentMacro/Macro/SwiftEnvironmentMacroError.swift
+++ b/Sources/SwiftEnvironmentMacro/Macro/SwiftEnvironmentMacroError.swift
@@ -10,6 +10,7 @@ import Foundation
 public enum SwiftEnvironmentMacroError: Error, CustomStringConvertible {
     case mustBeUsedInsideGlobalValues
     case expectedInitializerValue
+    case expectedTypeAnnotation
     
     public var description: String {
         switch self {
@@ -17,6 +18,8 @@ public enum SwiftEnvironmentMacroError: Error, CustomStringConvertible {
             return "The @GlobalEntry macro must be used inside a global values extensions."
         case .expectedInitializerValue:
             return "Expected an initializer value for the property annotated with @GlobalEntry."
+        case .expectedTypeAnnotation:
+            return "Expected a type annotation for the property annotated with @GlobalEntry."
         }
     }
 }

--- a/Tests/SwiftEnvironmentTests/IntegrationTests.swift
+++ b/Tests/SwiftEnvironmentTests/IntegrationTests.swift
@@ -8,7 +8,6 @@
 
 import XCTest
 @testable import SwiftEnvironment
-import SwiftUI
 
 final class IntegrationTests: XCTestCase {
     


### PR DESCRIPTION
This pull request introduces several enhancements to the `SwiftEnvironment` package, focusing on improving concurrency, adding support for optional instance resolution, and extending macro functionality. The most important changes include replacing `DispatchSemaphore` with `DispatchQueue` for thread-safe access, introducing the `OptionalTransientInstanceResolver` for optional value resolution, and expanding the `GlobalEntryMacro` to include peer declarations.

### Concurrency Improvements:
* Replaced `DispatchSemaphore` with `DispatchQueue` for thread-safe access in `GlobalValues`, using a concurrent queue with `.barrier` flags for atomic operations. (`Sources/SwiftEnvironment/Environment/GlobalValues.swift`, [[1]](diffhunk://#diff-31a1d7534c3301b182d1fdbfcee51112cbf76ec2045abcce62b8d35692cb6099R11-R16) [[2]](diffhunk://#diff-31a1d7534c3301b182d1fdbfcee51112cbf76ec2045abcce62b8d35692cb6099L49-R95)

### Instance Resolution Enhancements:
* Added `OptionalTransientInstanceResolver` to support optional value resolution in instance resolvers, allowing more flexible handling of optional types. (`Sources/SwiftEnvironment/InstanceResolver/TransientInstanceResolver.swift`, [Sources/SwiftEnvironment/InstanceResolver/TransientInstanceResolver.swiftR30-R50](diffhunk://#diff-0d8d6026ded8ea5dc9e3b4381211a05be07107c7a6364a4f1041a868c24eca3eR30-R50))

### Macro Functionality Extensions:
* Extended `GlobalEntryMacro` to support peer declarations, enabling the generation of prefixed static properties for global values. (`Sources/SwiftEnvironmentMacro/Macro/GlobalEntryMacro.swift`, [Sources/SwiftEnvironmentMacro/Macro/GlobalEntryMacro.swiftL13-R54](diffhunk://#diff-ec16521893343ab6408bdb6cc51e36bdc55e1a22788d6604e18fd7343549c3dfL13-R54))
* Added a new error case, `expectedTypeAnnotation`, to `SwiftEnvironmentMacroError` for better error handling when type annotations are missing in macro expansions. (`Sources/SwiftEnvironmentMacro/Macro/SwiftEnvironmentMacroError.swift`, [Sources/SwiftEnvironmentMacro/Macro/SwiftEnvironmentMacroError.swiftR13-R22](diffhunk://#diff-d9f3f16e7e2a7ab7620a65dcfd607254ddd9d3bf49e4b9f3a9d261c73f911844R13-R22))

### Miscellaneous Updates:
* Updated imports to include necessary modules (`Foundation` and `Chary`) for new functionality. (`Sources/SwiftEnvironment/Environment/GlobalValues.swift`, [[1]](diffhunk://#diff-31a1d7534c3301b182d1fdbfcee51112cbf76ec2045abcce62b8d35692cb6099R11-R16); `Sources/SwiftEnvironment/Macros.swift`, [[2]](diffhunk://#diff-8d2e3c8ab529f5d3e3e79780bcde7dbbb7f71a69459c558514eeda1a4ef024c2R8-R11)