### PR TITLE
Thread Safety On Macro and Property Wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,6 @@ extension GlobalValues {
 }
 ```
 
-if your value is `Sendable`, you need to tell the Macro that it's isolated, unless it will marked as nonisolated and gives a compiler warning:
-
-```swift
-extension GlobalValues {
-    @GlobalEntry(.isolated) var myValue: SomeDependency = SomeDependency()
-}
-```
-
 ### Accessing Global Values
 
 Access global values directly:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To install using Xcode's Swift Package Manager:
 
 1. Go to **File > Swift Package > Add Package Dependency**
 2. Enter the URL: **<https://github.com/hainayanda/SwiftEnvironment.git>**
-3. Choose **Up to Next Major** for the version rule and set the version to **4.1.3**
+3. Choose **Up to Next Major** for the version rule and set the version to **4.1.4**
 4. Click "Next" and wait for the package to be fetched
 
 ### Swift Package Manager (Package.swift)
@@ -34,7 +34,7 @@ To add SwiftEnvironment as a dependency in your **Package.swift** file:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/hainayanda/SwiftEnvironment.git", .upToNextMajor(from: "4.1.3"))
+    .package(url: "https://github.com/hainayanda/SwiftEnvironment.git", .upToNextMajor(from: "4.1.4"))
 ]
 ```
 

--- a/Sources/SwiftEnvironment/Environment/GlobalEnvironment.swift
+++ b/Sources/SwiftEnvironment/Environment/GlobalEnvironment.swift
@@ -9,12 +9,13 @@ import Foundation
 import Combine
 import SwiftUI
 
+private let accessQueue = DispatchQueue(label: "GlobalEnvironment.accessQueue", attributes: .concurrent)
+
 @propertyWrapper
 public final class GlobalEnvironment<Value>: DynamicProperty, PropertyWrapperDiscardable, @unchecked Sendable {
     
     private let keyPath: KeyPath<GlobalValues, Value>
     private var cancellables: Set<AnyCancellable> = []
-    private let accessQueue = DispatchQueue(label: "GlobalEnvironment.accessQueue_\(UUID())", attributes: .concurrent)
     
     
     @State private var lastAssignmentId: UUID?

--- a/Sources/SwiftEnvironment/Environment/GlobalEnvironment.swift
+++ b/Sources/SwiftEnvironment/Environment/GlobalEnvironment.swift
@@ -17,7 +17,6 @@ public final class GlobalEnvironment<Value>: DynamicProperty, PropertyWrapperDis
     private let keyPath: KeyPath<GlobalValues, Value>
     private var cancellables: Set<AnyCancellable> = []
     
-    
     @State private var lastAssignmentId: UUID?
     @State private var injectedValue: Value?
     private lazy var resolvedValue: Value = GlobalValues()[keyPath: keyPath]

--- a/Sources/SwiftEnvironment/Environment/GlobalValues.swift
+++ b/Sources/SwiftEnvironment/Environment/GlobalValues.swift
@@ -88,7 +88,7 @@ public struct GlobalValues: @unchecked Sendable {
         }
     }
     
-    private static func atomicRead<Result>(_ block: () throws -> Result) rethrows -> Result {
+    public static func atomicRead<Result>(_ block: () throws -> Result) rethrows -> Result {
         try accessQueue.safeSync {
             try block()
         }

--- a/Sources/SwiftEnvironment/Macros.swift
+++ b/Sources/SwiftEnvironment/Macros.swift
@@ -8,12 +8,7 @@
 import Foundation
 
 @attached(accessor)
-@attached(peer, names: prefixed(___))
-public macro GlobalEntry(_ modifier: StaticModifier = .nonisolated) = #externalMacro(
+@attached(peer, names: prefixed(___), prefixed(___ValueWrapper_))
+public macro GlobalEntry() = #externalMacro(
     module: "SwiftEnvironmentMacro", type: "GlobalEntryMacro"
 )
-
-public enum StaticModifier {
-    case isolated
-    case nonisolated
-}

--- a/Sources/SwiftEnvironmentMacro/Macro/GlobalEntryMacro.swift
+++ b/Sources/SwiftEnvironmentMacro/Macro/GlobalEntryMacro.swift
@@ -27,7 +27,7 @@ public struct GlobalEntryMacro: AccessorMacro, PeerMacro {
                 """
                 get {
                     GlobalValues.atomicRead {
-                        self[\\.\(raw: varName)] ?? GlobalValues.___\(raw: varName)
+                        self[\\.\(raw: varName)] ?? GlobalValues.___\(raw: varName).value
                     }
                 }
                 """
@@ -50,95 +50,21 @@ public struct GlobalEntryMacro: AccessorMacro, PeerMacro {
         guard let typeAnnotation = binding.typeAnnotation else {
             throw SwiftEnvironmentMacroError.expectedTypeAnnotation
         }
-        let modifier = isIsolated(node, typeAnnotation: typeAnnotation) ? "" : "nonisolated(unsafe) "
+        let typeString = typeAnnotation.type.trimmedDescription
+        let isolatedWrapper: String = "___ValueWrapper_\(varName)"
         return [
             DeclSyntax(
                 """
-                \(raw: modifier)private static let ___\(raw: varName): \(raw: typeAnnotation.type.trimmedDescription) = \(initializer)
+                private static let ___\(raw: varName): \(raw: isolatedWrapper) = \(raw: isolatedWrapper)()
+                """
+            ),
+            DeclSyntax(
+                """
+                private struct \(raw: isolatedWrapper): @unchecked Sendable {
+                    let value: \(raw: typeString) = \(initializer)
+                }
                 """
             )
         ]
     }
-    
-    private static func isIsolated(_ node: AttributeSyntax, typeAnnotation: TypeAnnotationSyntax) -> Bool {
-        guard !isDefaultSendable(typeAnnotation.type) else {
-            return true
-        }
-        guard let arguments = node.arguments?.as(LabeledExprListSyntax.self),
-              let firstArgument = arguments.first,
-              let expression = firstArgument.expression.as(MemberAccessExprSyntax.self) else {
-            return false
-        }
-        let description = expression.trimmedDescription
-        return description == ".isolated" || description == "StaticModifier.isolated"
-    }
-    
-    private static func isDefaultSendable(_ typeSyntax: TypeSyntax) -> Bool {
-        switch typeSyntax.as(TypeSyntaxEnum.self) {
-            
-            // Simple identifier like Int, String, etc.
-        case .identifierType(let simpleType):
-            let name = simpleType.name.trimmed.text
-            return defaultSendableNames.contains(name) || qualifiedSendableNames.contains(simpleType.description)
-            
-            // Optional like Int? or Optional<Int>
-        case .optionalType(let optionalType):
-            return isDefaultSendable(optionalType.wrappedType)
-            
-            // Array like [Int] or Array<Int>
-        case .arrayType(let arrayType):
-            return isDefaultSendable(arrayType.element)
-            
-            // Dictionary like [String: Int]
-        case .dictionaryType(let dictType):
-            return isDefaultSendable(dictType.key) && isDefaultSendable(dictType.value)
-            
-            // Tuple like (Int, String)
-        case .tupleType(let tupleType):
-            return tupleType.elements.allSatisfy { isDefaultSendable($0.type) }
-            
-            // Attributed or parenthesized types
-        case .attributedType(let attrType):
-            return isDefaultSendable(attrType.baseType)
-            
-        case .someOrAnyType(let someType): // for e.g. some Sendable
-            return isDefaultSendable(someType.constraint)
-            
-        default:
-            return false
-        }
-    }
-    
-    private static let defaultSendableNames: Set<String> = {
-        Set(qualifiedSendableNames.compactMap { $0.components(separatedBy: ".").last })
-    }()
-    
-    private static let qualifiedSendableNames: Set<String> = [
-        // Swift primitives
-        "Swift.Int", "Swift.Int8", "Swift.Int16", "Swift.Int32", "Swift.Int64",
-        "Swift.UInt", "Swift.UInt8", "Swift.UInt16", "Swift.UInt32", "Swift.UInt64",
-        "Swift.Double", "Swift.Float", "Swift.Float16", "CoreGraphics.CGFloat",
-        "Swift.Bool", "Swift.String", "Swift.Character", "Swift.StaticString",
-        "Swift.Void", "Swift.Never",
-        
-        // Foundation structs
-        "Foundation.Data", "Foundation.Date", "Foundation.UUID", "Foundation.URL", "Foundation.Decimal",
-        "Foundation.IndexPath", "Foundation.IndexSet",
-        "Foundation.TimeZone", "Foundation.Locale", "Foundation.Calendar",
-        "Foundation.Measurement", "Foundation.DateComponents", "Foundation.URLComponents",
-        "Foundation.URLRequest", "Foundation.URLResponse", "Foundation.TimeInterval",
-        
-        // CoreGraphics
-        "CoreGraphics.CGPoint", "CoreGraphics.CGSize", "CoreGraphics.CGRect", "CoreGraphics.CGVector", "CoreGraphics.CGAffineTransform",
-        
-        // Ranges
-        "Swift.Range", "Swift.ClosedRange", "Swift.StrideThrough", "Swift.StrideTo",
-        
-        // UIKit
-        "UIKit.UIEdgeInsets", "UIKit.UIOffset",
-        
-        // SwiftUI
-        "SwiftUI.Angle", "SwiftUI.EdgeInsets"
-    ]
-    
 }

--- a/Sources/SwiftEnvironmentMacro/Macro/GlobalEntryMacro.swift
+++ b/Sources/SwiftEnvironmentMacro/Macro/GlobalEntryMacro.swift
@@ -47,11 +47,10 @@ public struct GlobalEntryMacro: AccessorMacro, PeerMacro {
         else {
             throw SwiftEnvironmentMacroError.expectedInitializerValue
         }
-        let modifier = isIsolated(node) ? "" : "nonisolated(unsafe) "
-        
         guard let typeAnnotation = binding.typeAnnotation else {
             throw SwiftEnvironmentMacroError.expectedTypeAnnotation
         }
+        let modifier = isIsolated(node, typeAnnotation: typeAnnotation) ? "" : "nonisolated(unsafe) "
         return [
             DeclSyntax(
                 """
@@ -61,7 +60,10 @@ public struct GlobalEntryMacro: AccessorMacro, PeerMacro {
         ]
     }
     
-    private static func isIsolated(_ node: AttributeSyntax) -> Bool {
+    private static func isIsolated(_ node: AttributeSyntax, typeAnnotation: TypeAnnotationSyntax) -> Bool {
+        guard !isDefaultSendable(typeAnnotation.type) else {
+            return true
+        }
         guard let arguments = node.arguments?.as(LabeledExprListSyntax.self),
               let firstArgument = arguments.first,
               let expression = firstArgument.expression.as(MemberAccessExprSyntax.self) else {
@@ -70,4 +72,73 @@ public struct GlobalEntryMacro: AccessorMacro, PeerMacro {
         let description = expression.trimmedDescription
         return description == ".isolated" || description == "StaticModifier.isolated"
     }
+    
+    private static func isDefaultSendable(_ typeSyntax: TypeSyntax) -> Bool {
+        switch typeSyntax.as(TypeSyntaxEnum.self) {
+            
+            // Simple identifier like Int, String, etc.
+        case .identifierType(let simpleType):
+            let name = simpleType.name.trimmed.text
+            return defaultSendableNames.contains(name) || qualifiedSendableNames.contains(simpleType.description)
+            
+            // Optional like Int? or Optional<Int>
+        case .optionalType(let optionalType):
+            return isDefaultSendable(optionalType.wrappedType)
+            
+            // Array like [Int] or Array<Int>
+        case .arrayType(let arrayType):
+            return isDefaultSendable(arrayType.element)
+            
+            // Dictionary like [String: Int]
+        case .dictionaryType(let dictType):
+            return isDefaultSendable(dictType.key) && isDefaultSendable(dictType.value)
+            
+            // Tuple like (Int, String)
+        case .tupleType(let tupleType):
+            return tupleType.elements.allSatisfy { isDefaultSendable($0.type) }
+            
+            // Attributed or parenthesized types
+        case .attributedType(let attrType):
+            return isDefaultSendable(attrType.baseType)
+            
+        case .someOrAnyType(let someType): // for e.g. some Sendable
+            return isDefaultSendable(someType.constraint)
+            
+        default:
+            return false
+        }
+    }
+    
+    private static let defaultSendableNames: Set<String> = {
+        Set(qualifiedSendableNames.compactMap { $0.components(separatedBy: ".").last })
+    }()
+    
+    private static let qualifiedSendableNames: Set<String> = [
+        // Swift primitives
+        "Swift.Int", "Swift.Int8", "Swift.Int16", "Swift.Int32", "Swift.Int64",
+        "Swift.UInt", "Swift.UInt8", "Swift.UInt16", "Swift.UInt32", "Swift.UInt64",
+        "Swift.Double", "Swift.Float", "Swift.Float16", "CoreGraphics.CGFloat",
+        "Swift.Bool", "Swift.String", "Swift.Character", "Swift.StaticString",
+        "Swift.Void", "Swift.Never",
+        
+        // Foundation structs
+        "Foundation.Data", "Foundation.Date", "Foundation.UUID", "Foundation.URL", "Foundation.Decimal",
+        "Foundation.IndexPath", "Foundation.IndexSet",
+        "Foundation.TimeZone", "Foundation.Locale", "Foundation.Calendar",
+        "Foundation.Measurement", "Foundation.DateComponents", "Foundation.URLComponents",
+        "Foundation.URLRequest", "Foundation.URLResponse", "Foundation.TimeInterval",
+        
+        // CoreGraphics
+        "CoreGraphics.CGPoint", "CoreGraphics.CGSize", "CoreGraphics.CGRect", "CoreGraphics.CGVector", "CoreGraphics.CGAffineTransform",
+        
+        // Ranges
+        "Swift.Range", "Swift.ClosedRange", "Swift.StrideThrough", "Swift.StrideTo",
+        
+        // UIKit
+        "UIKit.UIEdgeInsets", "UIKit.UIOffset",
+        
+        // SwiftUI
+        "SwiftUI.Angle", "SwiftUI.EdgeInsets"
+    ]
+    
 }

--- a/Sources/SwiftEnvironmentMacro/Macro/GlobalEntryMacro.swift
+++ b/Sources/SwiftEnvironmentMacro/Macro/GlobalEntryMacro.swift
@@ -26,7 +26,9 @@ public struct GlobalEntryMacro: AccessorMacro, PeerMacro {
             AccessorDeclSyntax(
                 """
                 get {
-                    self[\\.\(raw: varName)] ?? GlobalValues.___\(raw: varName)
+                    GlobalValues.atomicRead {
+                        self[\\.\(raw: varName)] ?? GlobalValues.___\(raw: varName)
+                    }
                 }
                 """
             )

--- a/Tests/SwiftEnvironmentTests/DummyDependency.swift
+++ b/Tests/SwiftEnvironmentTests/DummyDependency.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import SwiftEnvironment
+import SwiftUICore
 
 protocol DummyDependency: AnyObject {
     var id: UUID { get }
@@ -31,5 +32,5 @@ extension GlobalValues {
     @GlobalEntry var thirdDummy: DummyDependency = DummyClass()
     @GlobalEntry var fourthDummy: DummyDependency = DummyClass()
     @GlobalEntry var fifthDummy: String = "dummy"
-    @GlobalEntry(.isolated) var sixthDummy: DummyDependency = DummyClass()
+    @GlobalEntry var sixthDummy: DummySendableDependency = DummySendableClass()
 }

--- a/Tests/SwiftEnvironmentTests/IntegrationTests.swift
+++ b/Tests/SwiftEnvironmentTests/IntegrationTests.swift
@@ -25,6 +25,15 @@ final class IntegrationTests: XCTestCase {
         XCTAssertFalse(dummy1 === dummy2)
     }
     
+    func test_givenSendableInjection_whenGet_shouldAlwaysReturnNewValue() {
+        GlobalValues.transient(\.sixthDummy, DummySendableClass())
+        
+        @GlobalEnvironment(\.sixthDummy) var dummy1
+        @GlobalEnvironment(\.sixthDummy) var dummy2
+        
+        XCTAssertFalse(dummy1.id == dummy2.id)
+    }
+    
     func test_givenConnectedInjection_whenGet_shouldAlwaysReturnSameValue() {
         GlobalValues.environment(\.dummy, DummyClass())
         GlobalValues.use(\.dummy, for: \.secondDummy)

--- a/Tests/SwiftEnvironmentTests/MacroTests.swift
+++ b/Tests/SwiftEnvironmentTests/MacroTests.swift
@@ -37,7 +37,9 @@ private let basicExpansion = #"""
 extension GlobalValues {
     var dummy: DummyDependency {
         get {
-            self[\.dummy] ?? GlobalValues.___dummy
+            GlobalValues.atomicRead {
+                self[\.dummy] ?? GlobalValues.___dummy
+            }
         }
     }
 
@@ -55,7 +57,9 @@ private let isolatedExpansion = #"""
 extension GlobalValues {
     var dummy: DummyDependency {
         get {
-            self[\.dummy] ?? GlobalValues.___dummy
+            GlobalValues.atomicRead {
+                self[\.dummy] ?? GlobalValues.___dummy
+            }
         }
     }
 

--- a/Tests/SwiftEnvironmentTests/MacroTests.swift
+++ b/Tests/SwiftEnvironmentTests/MacroTests.swift
@@ -18,20 +18,6 @@ final class MacroTests: XCTestCase {
             macros: ["GlobalEntry": GlobalEntryMacro.self]
         )
     }
-    
-    func test_givenIsolatedEntry_whenExpanded_shouldUseIsolatedExpansion() {
-        assertMacroExpansion(
-            isolated, expandedSource: isolatedExpansion,
-            macros: ["GlobalEntry": GlobalEntryMacro.self]
-        )
-    }
-    
-    func test_givenSendableEntry_whenExpanded_shouldUseSendableExpansion() {
-        assertMacroExpansion(
-            defaultSendable, expandedSource: defaultSendableExpansion,
-            macros: ["GlobalEntry": GlobalEntryMacro.self]
-        )
-    }
 }
 
 private let basic = #"""
@@ -45,72 +31,16 @@ extension GlobalValues {
     var dummy: DummyDependency {
         get {
             GlobalValues.atomicRead {
-                self[\.dummy] ?? GlobalValues.___dummy
+                self[\.dummy] ?? GlobalValues.___dummy.value
             }
         }
     }
 
-    nonisolated(unsafe) private static let ___dummy: DummyDependency = DummyClass()
-}
-"""#
+    private static let ___dummy: ___ValueWrapper_dummy = ___ValueWrapper_dummy()
 
-private let isolated = #"""
-extension GlobalValues {
-    @GlobalEntry(.isolated) var dummy: DummyDependency = DummyClass()
-}
-"""#
-
-private let isolatedExpansion = #"""
-extension GlobalValues {
-    var dummy: DummyDependency {
-        get {
-            GlobalValues.atomicRead {
-                self[\.dummy] ?? GlobalValues.___dummy
-            }
-        }
+    private struct ___ValueWrapper_dummy: @unchecked Sendable {
+        let value: DummyDependency = DummyClass()
     }
-
-    private static let ___dummy: DummyDependency = DummyClass()
-}
-"""#
-
-private let defaultSendable = #"""
-extension GlobalValues {
-    @GlobalEntry var dummy1: String = ""
-    @GlobalEntry var dummy2: [String] = []
-    @GlobalEntry var dummy3: String? = nil
-}
-"""#
-
-private let defaultSendableExpansion = #"""
-extension GlobalValues {
-    var dummy1: String {
-        get {
-            GlobalValues.atomicRead {
-                self[\.dummy1] ?? GlobalValues.___dummy1
-            }
-        }
-    }
-
-    private static let ___dummy1: String = ""
-    var dummy2: [String] {
-        get {
-            GlobalValues.atomicRead {
-                self[\.dummy2] ?? GlobalValues.___dummy2
-            }
-        }
-    }
-
-    private static let ___dummy2: [String] = []
-    var dummy3: String? {
-        get {
-            GlobalValues.atomicRead {
-                self[\.dummy3] ?? GlobalValues.___dummy3
-            }
-        }
-    }
-
-    private static let ___dummy3: String? = nil
 }
 """#
 #endif

--- a/Tests/SwiftEnvironmentTests/MacroTests.swift
+++ b/Tests/SwiftEnvironmentTests/MacroTests.swift
@@ -25,6 +25,13 @@ final class MacroTests: XCTestCase {
             macros: ["GlobalEntry": GlobalEntryMacro.self]
         )
     }
+    
+    func test_givenSendableEntry_whenExpanded_shouldUseSendableExpansion() {
+        assertMacroExpansion(
+            defaultSendable, expandedSource: defaultSendableExpansion,
+            macros: ["GlobalEntry": GlobalEntryMacro.self]
+        )
+    }
 }
 
 private let basic = #"""
@@ -64,6 +71,46 @@ extension GlobalValues {
     }
 
     private static let ___dummy: DummyDependency = DummyClass()
+}
+"""#
+
+private let defaultSendable = #"""
+extension GlobalValues {
+    @GlobalEntry var dummy1: String = ""
+    @GlobalEntry var dummy2: [String] = []
+    @GlobalEntry var dummy3: String? = nil
+}
+"""#
+
+private let defaultSendableExpansion = #"""
+extension GlobalValues {
+    var dummy1: String {
+        get {
+            GlobalValues.atomicRead {
+                self[\.dummy1] ?? GlobalValues.___dummy1
+            }
+        }
+    }
+
+    private static let ___dummy1: String = ""
+    var dummy2: [String] {
+        get {
+            GlobalValues.atomicRead {
+                self[\.dummy2] ?? GlobalValues.___dummy2
+            }
+        }
+    }
+
+    private static let ___dummy2: [String] = []
+    var dummy3: String? {
+        get {
+            GlobalValues.atomicRead {
+                self[\.dummy3] ?? GlobalValues.___dummy3
+            }
+        }
+    }
+
+    private static let ___dummy3: String? = nil
 }
 """#
 #endif


### PR DESCRIPTION
This pull request introduces significant changes to the `SwiftEnvironment` library, focusing on concurrency safety, simplifying macro usage, and updating documentation. Key updates include the introduction of atomic access methods for thread safety, the removal of the `StaticModifier` enum, and updates to tests and documentation to reflect these changes.

### Concurrency and Thread Safety
* Added a private `accessQueue` with concurrent attributes in `GlobalEnvironment.swift` to ensure thread-safe access to global values. Introduced `atomicRead` and `atomicWrite` methods for safe concurrent reads and writes. (`Sources/SwiftEnvironment/Environment/GlobalEnvironment.swift`: [[1]](diffhunk://#diff-42377771dbd246c411a6af35bcd386e2d70e276e69a75417ec09de2b98e83993R12-R15) [[2]](diffhunk://#diff-42377771dbd246c411a6af35bcd386e2d70e276e69a75417ec09de2b98e83993L22-R33) [[3]](diffhunk://#diff-42377771dbd246c411a6af35bcd386e2d70e276e69a75417ec09de2b98e83993R42-R45) [[4]](diffhunk://#diff-42377771dbd246c411a6af35bcd386e2d70e276e69a75417ec09de2b98e83993R58-R69)
* Made `GlobalValues.atomicRead` publicly accessible for broader use. (`Sources/SwiftEnvironment/Environment/GlobalValues.swift`: [Sources/SwiftEnvironment/Environment/GlobalValues.swiftL91-R91](diffhunk://#diff-31a1d7534c3301b182d1fdbfcee51112cbf76ec2045abcce62b8d35692cb6099L91-R91))

### Macro Simplification
* Removed the `StaticModifier` enum and its associated logic for isolated/nonisolated modifiers. Simplified the `GlobalEntry` macro by introducing a new `___ValueWrapper` struct to handle value isolation. (`Sources/SwiftEnvironment/Macros.swift`: [[1]](diffhunk://#diff-8d2e3c8ab529f5d3e3e79780bcde7dbbb7f71a69459c558514eeda1a4ef024c2L11-L19) `Sources/SwiftEnvironmentMacro/Macro/GlobalEntryMacro.swift`: [[2]](diffhunk://#diff-ec16521893343ab6408bdb6cc51e36bdc55e1a22788d6604e18fd7343549c3dfL29-R31) [[3]](diffhunk://#diff-ec16521893343ab6408bdb6cc51e36bdc55e1a22788d6604e18fd7343549c3dfL48-L70)

### Documentation Updates
* Updated the `README.md` to reflect the new version of the library (`4.1.4`) and removed outdated examples related to the `StaticModifier` enum. (`README.md`: [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R28) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L37-R37) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L62-L69)

### Test Updates
* Updated tests to align with the new macro behavior and removed tests related to the `StaticModifier` enum. (`Tests/SwiftEnvironmentTests/DummyDependency.swift`: [[1]](diffhunk://#diff-be5f95175bd8f3d1fd410b53e21787f77d75362070c9fc82325aefb4254f4d65L34-R35) `Tests/SwiftEnvironmentTests/MacroTests.swift`: [[2]](diffhunk://#diff-d2985352a3f709ec7cfc09b043228843fa1cf860b76b096311032e9e85412c45L21-L27) [[3]](diffhunk://#diff-d2985352a3f709ec7cfc09b043228843fa1cf860b76b096311032e9e85412c45L40-L62)

### Dependency Updates
* Added `SwiftUICore` as a new import in `DummyDependency.swift`. (`Tests/SwiftEnvironmentTests/DummyDependency.swift`: [Tests/SwiftEnvironmentTests/DummyDependency.swiftR11](diffhunk://#diff-be5f95175bd8f3d1fd410b53e21787f77d75362070c9fc82325aefb4254f4d65R11))