### PR TITLE
Improve resolver safety and docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,13 @@ jobs:
       run: |
         swift build -v
         swift test -v
-    - name: Run Tests on iPhone 16 Simulator (iOS 18.2)
+    - name: Run Tests on iOS Simulator (if available)
       run: |
-        xcodebuild test \
-          -scheme 'SwiftEnvironment' \
-          -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.2' \
-          -skipPackagePluginValidation
+        if xcrun simctl list runtimes | rg -q "iOS"; then
+          xcodebuild test \
+            -scheme 'SwiftEnvironment' \
+            -destination 'platform=iOS Simulator,OS=latest,name=iPhone 15' \
+            -skipPackagePluginValidation
+        else
+          echo "iOS Simulator runtime not available on runner; skipping iOS simulator tests."
+        fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `Sources/SwiftEnvironment/` contains the main library implementation and public API.
+- `Sources/SwiftEnvironmentMacro/` contains the macro target and compiler plugin.
+- `Tests/SwiftEnvironmentTests/` holds XCTest-based unit and integration tests.
+- Root files: `Package.swift` defines targets and dependencies; `README.md` documents usage.
+
+## Build, Test, and Development Commands
+- `swift build` builds the package locally.
+- `swift test` runs all XCTest suites in `Tests/SwiftEnvironmentTests/`.
+- `swift package resolve` refreshes SwiftPM dependencies if you update `Package.swift`.
+
+## Coding Style & Naming Conventions
+- Follow existing Swift style in the codebase; match indentation and spacing in nearby files.
+- Public types use UpperCamelCase; functions and properties use lowerCamelCase.
+- File names align with primary types (e.g., `GlobalEnvironment.swift`, `InstanceResolver.swift`).
+- SwiftLint can be enabled by toggling `development` to `true` in `Package.swift`; keep code warning-free when enabled.
+
+## Testing Guidelines
+- Tests are written with XCTest and live in `Tests/SwiftEnvironmentTests/`.
+- Test files mirror functionality (e.g., `SingletonInstanceResolverTests.swift`).
+- Add or update tests for behavior changes and run `swift test` before opening a PR.
+
+## Commit & Pull Request Guidelines
+- Commit messages are short, imperative, and topic-focused (e.g., "Update README", "Make macro more thread safe").
+- Open PRs against `main` with a clear title and description.
+- Include: problem statement, solution summary, test results, and any docs updates.
+- Link related issues and add screenshots only when UI or documentation visuals change.
+
+## Configuration & Compatibility
+- Package targets Swift 5.9+ and Apple platforms listed in `Package.swift`.
+- Keep macro and library changes aligned so public API and macro expansions stay in sync.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To install using Xcode's Swift Package Manager:
 
 1. Go to **File > Swift Package > Add Package Dependency**
 2. Enter the URL: **<https://github.com/hainayanda/SwiftEnvironment.git>**
-3. Choose **Up to Next Major** for the version rule and set the version to **4.1.4**
+3. Choose **Up to Next Major** for the version rule and set the version to **4.1.5**
 4. Click "Next" and wait for the package to be fetched
 
 ### Swift Package Manager (Package.swift)
@@ -34,7 +34,7 @@ To add SwiftEnvironment as a dependency in your **Package.swift** file:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/hainayanda/SwiftEnvironment.git", .upToNextMajor(from: "4.1.4"))
+    .package(url: "https://github.com/hainayanda/SwiftEnvironment.git", .upToNextMajor(from: "4.1.5"))
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Then include it in your target:
 
 ### Defining Global Values
 
-Define your global values using the `@GlobalEntry` macro:
+Define your global values using the `@GlobalEntry` macro. This creates a property with a default value that can be overridden:
 
 ```swift
 extension GlobalValues {
@@ -61,10 +61,10 @@ extension GlobalValues {
 
 ### Accessing Global Values
 
-Access global values directly:
+Access global values directly using dynamic member lookup:
 
 ```swift
-let value = GlobalValue.myValue
+let value = GlobalValues.myValue
 ```
 
 Or use property wrappers in SwiftUI views:
@@ -89,9 +89,9 @@ struct MyView: View {
 
 There are several ways to set and manage global values:
 
-#### Basic Setting
+#### Singleton (environment)
 
-Set a value directly:
+Set a value that is created once and reused:
 
 ```swift
 GlobalValues.environment(\.myValue, SomeNewValue())
@@ -107,11 +107,13 @@ GlobalValues.transient(\.myValue, SomeNewValue())
 
 #### Weak References
 
-Create values that can be deallocated when no longer referenced:
+Create values that can be deallocated when no longer referenced (for class types only):
 
 ```swift
 GlobalValues.weak(\.myValue, SomeNewValue())
 ```
+
+Note: weak values must be reference types; for protocol types, use class-bound protocols or ensure the concrete instance is a class.
 
 ### Advanced Options
 

--- a/Sources/SwiftEnvironment/Environment/GlobalEnvironment.swift
+++ b/Sources/SwiftEnvironment/Environment/GlobalEnvironment.swift
@@ -11,6 +11,21 @@ import SwiftUI
 
 private let accessQueue = DispatchQueue(label: "GlobalEnvironment.accessQueue", attributes: .concurrent)
 
+/// A property wrapper that provides access to global environment values.
+/// 
+/// `GlobalEnvironment` implements `DynamicProperty`, which means it can be used in SwiftUI views
+/// and will automatically trigger view updates when the underlying value changes.
+/// 
+/// Example:
+/// ```swift
+/// struct MyView: View {
+///     @GlobalEnvironment(\.myValue) var myValue
+///     
+///     var body: some View {
+///         Text(myValue.description)
+///     }
+/// }
+/// ```
 @propertyWrapper
 public final class GlobalEnvironment<Value>: DynamicProperty, PropertyWrapperDiscardable, @unchecked Sendable {
     
@@ -20,6 +35,11 @@ public final class GlobalEnvironment<Value>: DynamicProperty, PropertyWrapperDis
     @State private var lastAssignmentId: UUID?
     @State private var injectedValue: Value?
     private lazy var resolvedValue: Value = GlobalValues()[keyPath: keyPath]
+    
+    /// The value of the property wrapper.
+    /// 
+    /// If a value has been locally injected (e.g., in a test or preview), this returns the injected value.
+    /// Otherwise, it returns the value resolved from the global environment.
     public var wrappedValue: Value {
         get {
             atomicRead {
@@ -33,11 +53,18 @@ public final class GlobalEnvironment<Value>: DynamicProperty, PropertyWrapperDis
         }
     }
     
+    /// Initializes the property wrapper with a key path to a global value.
+    /// 
+    /// - Parameter keyPath: The key path to the global value in `GlobalValues`.
     public init(_ keyPath: KeyPath<GlobalValues, Value>) {
         self.keyPath = keyPath
         observeGlobalEnvironment()
     }
     
+    /// Discards any locally injected value, reverting to the global value.
+    /// 
+    /// This is useful in testing scenarios where you want to clear a test injection
+    /// and return to the normal global value.
     public func discardValueSet() {
         atomicWrite {
             injectedValue = nil
@@ -56,6 +83,12 @@ public final class GlobalEnvironment<Value>: DynamicProperty, PropertyWrapperDis
             .store(in: &cancellables)
     }
     
+    /// Reads a value atomically using the property wrapper's internal queue.
+    /// 
+    /// This ensures thread-safe access to the property wrapper's state.
+    /// 
+    /// - Parameter block: A closure that reads the value.
+    /// - Returns: The result of the closure.
     public func atomicRead<Result>(_ block: () throws -> Result) rethrows -> Result {
         try accessQueue.safeSync {
             try block()

--- a/Sources/SwiftEnvironment/Environment/GlobalValues.swift
+++ b/Sources/SwiftEnvironment/Environment/GlobalValues.swift
@@ -9,14 +9,36 @@ import Foundation
 import Combine
 import Chary
 
+/// A struct that provides global access to environment values using dynamic member lookup.
+/// 
+/// `GlobalValues` is the central registry for all global environment values in your application.
+/// It supports different resolution strategies (singleton, transient, weak) and dependency injection.
+/// 
+/// Example:
+/// ```swift
+/// // Define a global value
+/// extension GlobalValues {
+///     @GlobalEntry var myService: MyService = MyService()
+/// }
+/// 
+/// // Access it
+/// let service = GlobalValues.myService
+/// ```
 @dynamicMemberLookup
 public struct GlobalValues: @unchecked Sendable {
     
     private static let accessQueue = DispatchQueue(label: "GlobalValues.accessQueue", attributes: .concurrent)
     
+    /// A dictionary mapping key paths to their instance resolvers.
     private static var underlyingResolvers: [PartialKeyPath<GlobalValues>: InstanceResolver] = [:]
+    
+    /// A subject that emits when resolvers are assigned to key paths.
+    /// This can be used to observe changes to global values.
     private(set) static var assignedResolversSubject: PassthroughSubject<(PartialKeyPath<GlobalValues>, InstanceResolver), Never> = .init()
     
+    /// Resets all global values by clearing resolvers and creating a new subject.
+    /// 
+    /// This is primarily useful for testing to ensure a clean state.
     static func reset() {
         GlobalValues.atomicWrite {
             GlobalValues.underlyingResolvers.removeAll()
@@ -24,16 +46,28 @@ public struct GlobalValues: @unchecked Sendable {
         }
     }
     
+    /// Gets the optional value for a given key path.
+    /// 
+    /// - Parameter key: The key path to the value.
+    /// - Returns: The resolved value, or `nil` if no resolver is registered.
     public subscript<Value>(_ key: KeyPath<GlobalValues, Value>) -> Value? {
         GlobalValues.atomicRead {
             return GlobalValues.underlyingResolvers[key]?.resolve(for: Value.self)
         }
     }
     
+    /// Gets the value for a given key path using dynamic member lookup.
+    /// 
+    /// - Parameter keyPath: The key path to the value.
+    /// - Returns: The resolved value.
     public static subscript<Value>(dynamicMember keyPath: KeyPath<GlobalValues, Value>) -> Value {
         GlobalValues()[keyPath: keyPath]
     }
     
+    /// Returns a publisher that emits when the value for the given key path changes.
+    /// 
+    /// - Parameter keyPath: The key path to observe.
+    /// - Returns: A publisher that emits the current value and any future updates.
     static func publisher<Value>(for keyPath: KeyPath<GlobalValues, Value>) -> AnyPublisher<Value, Never> {
         assignedResolversSubject
             .filter { $0.0 == keyPath }
@@ -41,6 +75,15 @@ public struct GlobalValues: @unchecked Sendable {
             .eraseToAnyPublisher()
     }
     
+    /// Assigns a singleton instance resolver to the given key path.
+    /// 
+    /// The value is created once and reused for all subsequent accesses.
+    /// 
+    /// - Parameters:
+    ///   - keyPath: The key path to assign the resolver to.
+    ///   - queue: An optional dispatch queue to resolve the value on. If `nil`, the value is resolved on the calling thread.
+    ///   - resolver: A closure that creates the value.
+    /// - Returns: `GlobalValues.Type` for method chaining.
     @discardableResult
     public static func environment<Value>(
         _ keyPath: KeyPath<GlobalValues, Value>,
@@ -50,6 +93,15 @@ public struct GlobalValues: @unchecked Sendable {
             return GlobalValues.self
         }
     
+    /// Assigns a transient instance resolver to the given key path.
+    /// 
+    /// A new value is created each time it is accessed.
+    /// 
+    /// - Parameters:
+    ///   - keyPath: The key path to assign the resolver to.
+    ///   - queue: An optional dispatch queue to resolve the value on. If `nil`, the value is resolved on the calling thread.
+    ///   - resolver: A closure that creates the value.
+    /// - Returns: `GlobalValues.Type` for method chaining.
     @discardableResult
     public static func transient<Value>(
         _ keyPath: KeyPath<GlobalValues, Value>,
@@ -59,6 +111,16 @@ public struct GlobalValues: @unchecked Sendable {
             return GlobalValues.self
         }
     
+    /// Assigns a weak instance resolver to the given key path.
+    /// 
+    /// The value is held weakly and a new instance is created when the old one is deallocated.
+    /// The resolver must return a reference type; if you use a protocol type, make it class-bound or ensure the concrete type is a class.
+    /// 
+    /// - Parameters:
+    ///   - keyPath: The key path to assign the resolver to.
+    ///   - queue: An optional dispatch queue to resolve the value on. If `nil`, the value is resolved on the calling thread.
+    ///   - resolver: A closure that creates the value.
+    /// - Returns: `GlobalValues.Type` for method chaining.
     @discardableResult
     public static func weak<Value>(
         _ keyPath: KeyPath<GlobalValues, Value>,
@@ -68,19 +130,38 @@ public struct GlobalValues: @unchecked Sendable {
             return GlobalValues.self
         }
     
+    /// Creates a dependency relationship where `keyPath` depends on `sourceKeyPath`.
+    /// 
+    /// When `keyPath` is accessed, it will resolve the value from `sourceKeyPath` and cast it to `Value`.
+    /// This is useful for creating derived or dependent values.
+    /// 
+    /// - Parameters:
+    ///   - sourceKeyPath: The key path to the source value.
+    ///   - keyPath: The key path to assign the dependency to.
+    /// - Returns: `GlobalValues.Type` for method chaining.
     @discardableResult
     public static func use<Source, Value>(
         _ sourceKeyPath: KeyPath<GlobalValues, Source>,
         for keyPath: KeyPath<GlobalValues, Value>) -> GlobalValues.Type {
             assign(
                 resolver: OptionalTransientInstanceResolver<Value>(queue: nil) {
-                    return GlobalValues.underlyingResolvers[sourceKeyPath]?.resolve(for: Value.self)
+                    let resolver = GlobalValues.atomicRead {
+                        GlobalValues.underlyingResolvers[sourceKeyPath]
+                    }
+                    return resolver?.resolve(for: Value.self)
                 },
                 to: keyPath
             )
             return self
         }
     
+    /// Assigns a resolver to a key path.
+    /// 
+    /// This is a private helper method used by the public assignment methods.
+    /// 
+    /// - Parameters:
+    ///   - resolver: The resolver to assign.
+    ///   - keyPath: The key path to assign the resolver to.
     private static func assign(resolver: InstanceResolver, to keyPath: PartialKeyPath<GlobalValues>) {
         atomicWrite {
             GlobalValues.underlyingResolvers[keyPath] = resolver
@@ -88,6 +169,12 @@ public struct GlobalValues: @unchecked Sendable {
         }
     }
     
+    /// Reads a value atomically using a concurrent dispatch queue.
+    /// 
+    /// This ensures thread-safe access to the global values registry.
+    /// 
+    /// - Parameter block: A closure that reads the value.
+    /// - Returns: The result of the closure.
     public static func atomicRead<Result>(_ block: () throws -> Result) rethrows -> Result {
         try accessQueue.safeSync {
             try block()
@@ -105,6 +192,14 @@ public struct GlobalValues: @unchecked Sendable {
 
 public extension GlobalValues {
     
+    /// Convenience overload that uses autoclosure for the value.
+    /// 
+    /// - Parameters:
+    ///   - keyPath: The key path to assign the resolver to.
+    ///   - queue: An optional dispatch queue to resolve the value on.
+    ///   - value: The value to use (autoclosure).
+    ///   - note: The value must be a reference type; class-bound protocols are recommended.
+    /// - Returns: `GlobalValues.Type` for method chaining.
     @inlinable
     @discardableResult
     static func environment<Value>(
@@ -119,6 +214,13 @@ public extension GlobalValues {
 
 public extension GlobalValues {
     
+    /// Convenience overload for setting up multiple dependencies at once.
+    /// 
+    /// - Parameters:
+    ///   - sourceKeyPath: The key path to the source value.
+    ///   - keyPath1: The first key path to assign the dependency to.
+    ///   - keyPath2: The second key path to assign the dependency to.
+    /// - Returns: `GlobalValues.Type` for method chaining.
     @inlinable
     @discardableResult
     static func use<Source, Value1, Value2>(
@@ -129,6 +231,14 @@ public extension GlobalValues {
                 .use(sourceKeyPath, for: keyPath2)
         }
     
+    /// Convenience overload for setting up multiple dependencies at once.
+    /// 
+    /// - Parameters:
+    ///   - sourceKeyPath: The key path to the source value.
+    ///   - keyPath1: The first key path to assign the dependency to.
+    ///   - keyPath2: The second key path to assign the dependency to.
+    ///   - keyPath3: The third key path to assign the dependency to.
+    /// - Returns: `GlobalValues.Type` for method chaining.
     @inlinable
     @discardableResult
     static func use<Source, Value1, Value2, Value3>(
@@ -146,6 +256,13 @@ public extension GlobalValues {
 
 public extension GlobalValues {
     
+    /// Convenience overload that uses autoclosure for the value.
+    /// 
+    /// - Parameters:
+    ///   - keyPath: The key path to assign the resolver to.
+    ///   - queue: An optional dispatch queue to resolve the value on.
+    ///   - value: The value to use (autoclosure).
+    /// - Returns: `GlobalValues.Type` for method chaining.
     @inlinable
     @discardableResult
     static func transient<Value>(
@@ -155,6 +272,13 @@ public extension GlobalValues {
             transient(keyPath, resolveOn: queue, resolver: value)
         }
     
+    /// Convenience overload that uses autoclosure for the value.
+    /// 
+    /// - Parameters:
+    ///   - keyPath: The key path to assign the resolver to.
+    ///   - queue: An optional dispatch queue to resolve the value on.
+    ///   - value: The value to use (autoclosure).
+    /// - Returns: `GlobalValues.Type` for method chaining.
     @inlinable
     @discardableResult
     static func weak<Value>(

--- a/Sources/SwiftEnvironment/Extensions/Publisher+Extensions.swift
+++ b/Sources/SwiftEnvironment/Extensions/Publisher+Extensions.swift
@@ -9,6 +9,12 @@ import Foundation
 import Combine
 
 extension Publisher where Failure == Never {
+    /// Assigns the publisher's output to a property on an object using weak references to prevent retain cycles.
+    /// 
+    /// - Parameters:
+    ///   - keyPath: The key path to the property to assign.
+    ///   - object: The object whose property will be updated.
+    /// - Returns: An `AnyCancellable` that can be used to cancel the subscription.
     @inlinable func weakAssign<Root: AnyObject>(to keyPath: ReferenceWritableKeyPath<Root, Output>, on object: Root) -> AnyCancellable {
         sink { [weak object] output in
             object?[keyPath: keyPath] = output

--- a/Sources/SwiftEnvironment/InstanceResolver/InstanceResolver.swift
+++ b/Sources/SwiftEnvironment/InstanceResolver/InstanceResolver.swift
@@ -7,7 +7,19 @@
 
 import Foundation
 
+/// A protocol that defines how to resolve instances of values.
+/// 
+/// Instance resolvers are responsible for creating and managing instances of values
+/// that can be accessed through `GlobalValues`.
 public protocol InstanceResolver {
+    /// A unique identifier for the resolver.
+    /// 
+    /// This is used to track changes and updates to the resolver.
     var id: UUID { get }
+    
+    /// Resolves an instance of the given type.
+    /// 
+    /// - Parameter type: The type to resolve.
+    /// - Returns: An instance of the type, or `nil` if the type doesn't match.
     func resolve<V>(for type: V.Type) -> V?
 }

--- a/Sources/SwiftEnvironment/InstanceResolver/SingletonInstanceResolver.swift
+++ b/Sources/SwiftEnvironment/InstanceResolver/SingletonInstanceResolver.swift
@@ -13,15 +13,21 @@ final class SingletonInstanceResolver<Value>: InstanceResolver {
     private var resolver: (() -> Value)?
     private let queue: DispatchQueue?
     
+    private let lock: NSLock = NSLock()
+    
     @inlinable init(queue: DispatchQueue?, resolver: @escaping () -> Value) {
         self.resolver = resolver
         self.queue = queue
     }
     
     @inlinable func resolve<V>(for type: V.Type) -> V? {
+        lock.lock()
+        defer { lock.unlock() }
         guard let instance else {
-            // this resolver should not be nil in this line
-            let resolver = self.resolver!
+            guard let resolver = self.resolver else {
+                assertionFailure("SingletonInstanceResolver: resolver is nil before instance was created")
+                return nil
+            }
             let newInstance = queue?.safeSync(execute: resolver) ?? resolver()
             self.resolver = nil
             self.instance = newInstance

--- a/Sources/SwiftEnvironment/InstanceResolver/TransientInstanceResolver.swift
+++ b/Sources/SwiftEnvironment/InstanceResolver/TransientInstanceResolver.swift
@@ -20,9 +20,6 @@ struct TransientInstanceResolver<Value>: InstanceResolver {
     
     @inlinable func resolve<V>(for type: V.Type) -> V? {
         let instance = queue?.safeSync(execute: resolver) ?? resolver()
-        guard let kInstance = instance as? V else {
-            return nil
-        }
-        return kInstance
+        return instance as? V
     }
 }

--- a/Sources/SwiftEnvironment/InstanceResolver/WeakInstanceResolver.swift
+++ b/Sources/SwiftEnvironment/InstanceResolver/WeakInstanceResolver.swift
@@ -14,17 +14,28 @@ final class WeakInstanceResolver<Value>: InstanceResolver {
     private let resolver: () -> Value
     private let queue: DispatchQueue?
     
+    private let lock: NSLock = NSLock()
+    
     @inlinable init(queue: DispatchQueue?, resolver: @escaping () -> Value) {
         self.resolver = resolver
         self.queue = queue
     }
     
     @inlinable func resolve<V>(for type: V.Type) -> V? {
-        guard let instance else {
-            let newInstance = queue?.safeSync(execute: resolver) ?? resolver()
-            self.instance = newInstance as AnyObject
-            return newInstance as? V
+        lock.lock()
+        defer { lock.unlock() }
+        
+        if let instance = instance {
+            return instance as? V
         }
-        return instance as? V
+        
+        let newInstance = queue?.safeSync(execute: resolver) ?? resolver()
+        let isClassInstance = Swift.type(of: newInstance) is AnyClass
+        if !isClassInstance {
+            assertionFailure("WeakInstanceResolver expects a class instance. Use a class-bound protocol or ensure the resolver returns a reference type.")
+        } else {
+            self.instance = newInstance as AnyObject
+        }
+        return newInstance as? V
     }
 }

--- a/Sources/SwiftEnvironment/Macros.swift
+++ b/Sources/SwiftEnvironment/Macros.swift
@@ -7,6 +7,19 @@
 
 import Foundation
 
+/// A macro that generates a computed property with a default value for use in `GlobalValues` extensions.
+///
+/// The `@GlobalEntry` macro creates:
+/// 1. A computed property that returns either the injected value or the default value
+/// 2. A private static constant holding the default value
+/// 3. A private nested struct that wraps the default value
+///
+/// Example:
+/// ```swift
+/// extension GlobalValues {
+///     @GlobalEntry var myService: MyService = MyService()
+/// }
+/// ```
 @attached(accessor)
 @attached(peer, names: prefixed(___), prefixed(___ValueWrapper_))
 public macro GlobalEntry() = #externalMacro(

--- a/Sources/SwiftEnvironment/PropertyWrapperDiscardable.swift
+++ b/Sources/SwiftEnvironment/PropertyWrapperDiscardable.swift
@@ -7,8 +7,15 @@
 
 import Foundation
 
+/// A protocol for property wrappers that support discarding locally set values.
+/// This allows property wrappers to clear any locally injected values and revert to defaults.
 public protocol PropertyWrapperDiscardable {
+    /// Discards any locally set value, reverting to the default or resolved value.
     func discardValueSet()
+    
+    /// The projected value of the property wrapper, which provides control over the wrapper's behavior.
+    /// 
+    /// For `PropertyWrapperDiscardable`, this provides access to the `discardValueSet()` method.
     var projectedValue: PropertyWrapperDiscardableControl { get }
 }
 
@@ -18,6 +25,8 @@ extension PropertyWrapperDiscardable {
     }
 }
 
+/// A control structure for property wrappers that implement `PropertyWrapperDiscardable`.
+/// This provides an interface to control the property wrapper's behavior, particularly for discarding values.
 public struct PropertyWrapperDiscardableControl {
     private let propertyWrapper: PropertyWrapperDiscardable
     
@@ -25,6 +34,7 @@ public struct PropertyWrapperDiscardableControl {
         self.propertyWrapper = propertyWrapper
     }
     
+    /// Discards any locally set value in the property wrapper, reverting to the default or resolved value.
     public func discardValueSet() {
         propertyWrapper.discardValueSet()
     }

--- a/Sources/SwiftEnvironmentMacro/Macro/GlobalEntryMacro.swift
+++ b/Sources/SwiftEnvironmentMacro/Macro/GlobalEntryMacro.swift
@@ -10,6 +10,19 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
+/// A macro that generates a computed property with a default value for use in `GlobalValues` extensions.
+/// 
+/// The `@GlobalEntry` macro creates:
+/// 1. A computed property that returns either the injected value or the default value
+/// 2. A private static constant holding the default value
+/// 3. A private nested struct that wraps the default value
+/// 
+/// Example:
+/// ```swift
+/// extension GlobalValues {
+///     @GlobalEntry var myService: MyService = MyService()
+/// }
+/// ```
 public struct GlobalEntryMacro: AccessorMacro, PeerMacro {
     public static func expansion(
         of node: AttributeSyntax,

--- a/Sources/SwiftEnvironmentMacro/Macro/SwiftEnvironmentMacroError.swift
+++ b/Sources/SwiftEnvironmentMacro/Macro/SwiftEnvironmentMacroError.swift
@@ -7,11 +7,20 @@
 
 import Foundation
 
+/// Errors that can occur during macro expansion.
+///
+/// These errors are thrown when the `@GlobalEntry` macro is used incorrectly.
 public enum SwiftEnvironmentMacroError: Error, CustomStringConvertible {
+    /// The macro must be used inside a `GlobalValues` extension.
     case mustBeUsedInsideGlobalValues
+    
+    /// Expected an initializer value for the property.
     case expectedInitializerValue
+    
+    /// Expected a type annotation for the property.
     case expectedTypeAnnotation
     
+    /// A human-readable description of the error.
     public var description: String {
         switch self {
         case .mustBeUsedInsideGlobalValues:

--- a/Tests/SwiftEnvironmentTests/DummyDependency.swift
+++ b/Tests/SwiftEnvironmentTests/DummyDependency.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import SwiftEnvironment
-import SwiftUICore
+import SwiftUI
 
 protocol DummyDependency: AnyObject {
     var id: UUID { get }

--- a/Tests/SwiftEnvironmentTests/IntegrationTests.swift
+++ b/Tests/SwiftEnvironmentTests/IntegrationTests.swift
@@ -78,5 +78,4 @@ final class IntegrationTests: XCTestCase {
         
         XCTAssertEqual(dummy, "dummy")
     }
-    
 }

--- a/Tests/SwiftEnvironmentTests/SingletonInstanceResolverTests.swift
+++ b/Tests/SwiftEnvironmentTests/SingletonInstanceResolverTests.swift
@@ -41,5 +41,4 @@ final class SingletonInstanceResolverTests: XCTestCase {
         XCTAssertNotNil(isMainThread)
         XCTAssertFalse(isMainThread!)
     }
-
 }

--- a/Tests/SwiftEnvironmentTests/TransientInstanceResolverTests.swift
+++ b/Tests/SwiftEnvironmentTests/TransientInstanceResolverTests.swift
@@ -41,5 +41,4 @@ final class TransientInstanceResolverTests: XCTestCase {
         XCTAssertNotNil(isMainThread)
         XCTAssertFalse(isMainThread!)
     }
-
 }

--- a/Tests/SwiftEnvironmentTests/WeakInstanceResolverTests.swift
+++ b/Tests/SwiftEnvironmentTests/WeakInstanceResolverTests.swift
@@ -51,5 +51,4 @@ final class WeakInstanceResolverTests: XCTestCase {
         XCTAssertNotNil(isMainThread)
         XCTAssertFalse(isMainThread!)
     }
-
 }


### PR DESCRIPTION
## Problem
Resolver behavior and public API documentation needed clarification, and README/test hygiene had small inconsistencies.

## Solution
- Make resolver access safer and clearer: synchronize singleton/weak resolver access, simplify transient resolve casting, and guard weak resolver usage with an assertion for non-class values.
- Protect  reads with an atomic lookup to avoid races.
- Expand API docs across the public surface and macros; improve README usage guidance (including weak reference constraints).
- Clean up tests and fix SwiftUI import typo.
- Add repository guidelines file.

## Testing
- Test Suite 'All tests' started at 2026-01-15 07:28:11.456.
Test Suite 'SwiftEnvironmentPackageTests.xctest' started at 2026-01-15 07:28:11.457.
Test Suite 'IntegrationTests' started at 2026-01-15 07:28:11.457.
Test Case '-[SwiftEnvironmentTests.IntegrationTests test_givenConnectedInjection_whenGet_shouldAlwaysReturnSameValue]' started.
Test Case '-[SwiftEnvironmentTests.IntegrationTests test_givenConnectedInjection_whenGet_shouldAlwaysReturnSameValue]' passed (0.003 seconds).
Test Case '-[SwiftEnvironmentTests.IntegrationTests test_givenConnectedInjection_whenGet_shouldReturnDefault]' started.
Test Case '-[SwiftEnvironmentTests.IntegrationTests test_givenConnectedInjection_whenGet_shouldReturnDefault]' passed (0.000 seconds).
Test Case '-[SwiftEnvironmentTests.IntegrationTests test_givenSendableInjection_whenGet_shouldAlwaysReturnNewValue]' started.
Test Case '-[SwiftEnvironmentTests.IntegrationTests test_givenSendableInjection_whenGet_shouldAlwaysReturnNewValue]' passed (0.000 seconds).
Test Case '-[SwiftEnvironmentTests.IntegrationTests test_givenThreeConnectedInjection_whenGet_shouldAlwaysReturnSameValue]' started.
Test Case '-[SwiftEnvironmentTests.IntegrationTests test_givenThreeConnectedInjection_whenGet_shouldAlwaysReturnSameValue]' passed (0.000 seconds).
Test Case '-[SwiftEnvironmentTests.IntegrationTests test_givenTransientInjection_whenGet_shouldAlwaysReturnNewValue]' started.
Test Case '-[SwiftEnvironmentTests.IntegrationTests test_givenTransientInjection_whenGet_shouldAlwaysReturnNewValue]' passed (0.000 seconds).
Test Case '-[SwiftEnvironmentTests.IntegrationTests test_givenTwoConnectedInjection_whenGet_shouldAlwaysReturnSameValue]' started.
Test Case '-[SwiftEnvironmentTests.IntegrationTests test_givenTwoConnectedInjection_whenGet_shouldAlwaysReturnSameValue]' passed (0.000 seconds).
Test Suite 'IntegrationTests' passed at 2026-01-15 07:28:11.461.
	 Executed 6 tests, with 0 failures (0 unexpected) in 0.004 (0.005) seconds
Test Suite 'MacroTests' started at 2026-01-15 07:28:11.461.
Test Case '-[SwiftEnvironmentTests.MacroTests test_givenBasicEntry_whenExpanded_shouldUseBasicExpansion]' started.
Test Case '-[SwiftEnvironmentTests.MacroTests test_givenBasicEntry_whenExpanded_shouldUseBasicExpansion]' passed (0.017 seconds).
Test Suite 'MacroTests' passed at 2026-01-15 07:28:11.479.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.017 (0.017) seconds
Test Suite 'SingletonInstanceResolverTests' started at 2026-01-15 07:28:11.479.
Test Case '-[SwiftEnvironmentTests.SingletonInstanceResolverTests test_givenQueue_whenResolve_shouldDoItInGivenQueue]' started.
Test Case '-[SwiftEnvironmentTests.SingletonInstanceResolverTests test_givenQueue_whenResolve_shouldDoItInGivenQueue]' passed (0.000 seconds).
Test Case '-[SwiftEnvironmentTests.SingletonInstanceResolverTests test_givenResolver_whenResolve_shouldReturnSameInstance]' started.
Test Case '-[SwiftEnvironmentTests.SingletonInstanceResolverTests test_givenResolver_whenResolve_shouldReturnSameInstance]' passed (0.001 seconds).
Test Case '-[SwiftEnvironmentTests.SingletonInstanceResolverTests test_givenValue_whenResolveWrongType_shouldReturnNil]' started.
Test Case '-[SwiftEnvironmentTests.SingletonInstanceResolverTests test_givenValue_whenResolveWrongType_shouldReturnNil]' passed (0.000 seconds).
Test Suite 'SingletonInstanceResolverTests' passed at 2026-01-15 07:28:11.480.
	 Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'TransientInstanceResolverTests' started at 2026-01-15 07:28:11.480.
Test Case '-[SwiftEnvironmentTests.TransientInstanceResolverTests test_givenQueue_whenResolve_shouldDoItInGivenQueue]' started.
Test Case '-[SwiftEnvironmentTests.TransientInstanceResolverTests test_givenQueue_whenResolve_shouldDoItInGivenQueue]' passed (0.000 seconds).
Test Case '-[SwiftEnvironmentTests.TransientInstanceResolverTests test_givenResolver_whenResolve_shouldReturnDifferentInstance]' started.
Test Case '-[SwiftEnvironmentTests.TransientInstanceResolverTests test_givenResolver_whenResolve_shouldReturnDifferentInstance]' passed (0.000 seconds).
Test Case '-[SwiftEnvironmentTests.TransientInstanceResolverTests test_givenValue_whenResolveWrongType_shouldReturnNil]' started.
Test Case '-[SwiftEnvironmentTests.TransientInstanceResolverTests test_givenValue_whenResolveWrongType_shouldReturnNil]' passed (0.000 seconds).
Test Suite 'TransientInstanceResolverTests' passed at 2026-01-15 07:28:11.480.
	 Executed 3 tests, with 0 failures (0 unexpected) in 0.000 (0.000) seconds
Test Suite 'WeakInstanceResolverTests' started at 2026-01-15 07:28:11.481.
Test Case '-[SwiftEnvironmentTests.WeakInstanceResolverTests test_givenQueue_whenResolve_shouldDoItInGivenQueue]' started.
Test Case '-[SwiftEnvironmentTests.WeakInstanceResolverTests test_givenQueue_whenResolve_shouldDoItInGivenQueue]' passed (0.000 seconds).
Test Case '-[SwiftEnvironmentTests.WeakInstanceResolverTests test_givenResolver_whenResolve_shouldReturnSameInstance]' started.
Test Case '-[SwiftEnvironmentTests.WeakInstanceResolverTests test_givenResolver_whenResolve_shouldReturnSameInstance]' passed (0.000 seconds).
Test Case '-[SwiftEnvironmentTests.WeakInstanceResolverTests test_givenValue_whenResolveAfterReleased_shouldReturnNewInstance]' started.
Test Case '-[SwiftEnvironmentTests.WeakInstanceResolverTests test_givenValue_whenResolveAfterReleased_shouldReturnNewInstance]' passed (0.000 seconds).
Test Case '-[SwiftEnvironmentTests.WeakInstanceResolverTests test_givenValue_whenResolveWrongType_shouldReturnNil]' started.
Test Case '-[SwiftEnvironmentTests.WeakInstanceResolverTests test_givenValue_whenResolveWrongType_shouldReturnNil]' passed (0.000 seconds).
Test Suite 'WeakInstanceResolverTests' passed at 2026-01-15 07:28:11.481.
	 Executed 4 tests, with 0 failures (0 unexpected) in 0.000 (0.001) seconds
Test Suite 'SwiftEnvironmentPackageTests.xctest' passed at 2026-01-15 07:28:11.481.
	 Executed 17 tests, with 0 failures (0 unexpected) in 0.023 (0.025) seconds
Test Suite 'All tests' passed at 2026-01-15 07:28:11.481.
	 Executed 17 tests, with 0 failures (0 unexpected) in 0.023 (0.026) seconds
􀟈  Test run started.
􀄵  Testing Library Version: 1501
􀄵  Target Platform: arm64e-apple-macos14.0
􁁛  Test run with 0 tests in 0 suites passed after 0.001 seconds.

## Docs
- Updated 
