### PR TITLE
Fix GlobalEnvironment injected state refresh

### DIFF
--- a/.github/workflows/unused_code_check.yml
+++ b/.github/workflows/unused_code_check.yml
@@ -18,7 +18,13 @@ jobs:
       run: swift package resolve
     - name: Pick xcode 16.2
       run: sudo xcode-select -s '/Applications/Xcode_16.2.app/Contents/Developer'
+    - name: Install Periphery 3.5.1 (Swift 6.0 compatible)
+      run: |
+        curl -fsSL -o periphery.zip https://github.com/peripheryapp/periphery/releases/download/3.5.1/periphery-3.5.1.zip
+        unzip -q periphery.zip
+        chmod +x periphery
+        sudo mv periphery /usr/local/bin/periphery
+        periphery version
     - name: Run Periphery on MacOS
       run: |
-        brew install periphery
         periphery scan --strict

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
 Package.resolved
+.tools

--- a/Sources/SwiftEnvironment/Environment/GlobalEnvironment.swift
+++ b/Sources/SwiftEnvironment/Environment/GlobalEnvironment.swift
@@ -33,8 +33,7 @@ public final class GlobalEnvironment<Value>: DynamicProperty, PropertyWrapperDis
     private var cancellables: Set<AnyCancellable> = []
     
     @State private var lastAssignmentId: UUID?
-    @State private var injectedValueVersion: Int = 0
-
+    @State private var stateInjectedValue: Value?
     private var injectedValue: Value?
 
     private lazy var resolvedValue: Value = GlobalValues()[keyPath: keyPath]
@@ -45,17 +44,15 @@ public final class GlobalEnvironment<Value>: DynamicProperty, PropertyWrapperDis
     /// Otherwise, it returns the value resolved from the global environment.
     public var wrappedValue: Value {
         get {
-            atomicRead {
+            if Thread.isMainThread, let stateInjectedValue {
+                return stateInjectedValue
+            }
+            return atomicRead {
                 injectedValue ?? resolvedValue
             }
         }
         set {
-            atomicWrite {
-                injectedValue = newValue
-            }
-            DispatchQueue.main.async { [weak self] in
-                self?.injectedValueVersion &+= 1
-            }
+            setInjectedValue(newValue)
         }
     }
     
@@ -72,12 +69,7 @@ public final class GlobalEnvironment<Value>: DynamicProperty, PropertyWrapperDis
     /// This is useful in testing scenarios where you want to clear a test injection
     /// and return to the normal global value.
     public func discardValueSet() {
-        atomicWrite {
-            injectedValue = nil
-        }
-        DispatchQueue.main.async { [weak self] in
-            self?.injectedValueVersion = 0
-        }
+        setInjectedValue(nil)
     }
     
     private func observeGlobalEnvironment() {
@@ -88,7 +80,7 @@ public final class GlobalEnvironment<Value>: DynamicProperty, PropertyWrapperDis
         GlobalValues.assignedResolversSubject
             .map { $0.1.id }
             .removeDuplicates()
-            .receive(on: DispatchQueue.main)
+            .ensureOnMain()
             .weakAssign(to: \.lastAssignmentId, on: self)
             .store(in: &cancellables)
     }
@@ -99,15 +91,27 @@ public final class GlobalEnvironment<Value>: DynamicProperty, PropertyWrapperDis
     /// 
     /// - Parameter block: A closure that reads the value.
     /// - Returns: The result of the closure.
-    public func atomicRead<Result>(_ block: () throws -> Result) rethrows -> Result {
-        try accessQueue.safeSync {
-            try block()
-        }
+    public func atomicRead<Result>(onMain: Bool = false, _ block: () throws -> Result) rethrows -> Result {
+        return try atomicRun(onMain: onMain, block)
     }
     
-    private func atomicWrite<Result>(_ block: () throws -> Result) rethrows -> Result {
-        try accessQueue.safeSync(flags: .barrier) {
-            try block()
+    private func atomicWrite<Result>(onMain: Bool = false, _ block: () throws -> Result) rethrows -> Result {
+        return try atomicRun(flags: .barrier, onMain: onMain, block)
+    }
+    
+    private func atomicRun<Result>(flags: DispatchWorkItemFlags = [], onMain: Bool = false, _ block: () throws -> Result) rethrows -> Result {
+        guard onMain else {
+            return try accessQueue.safeSync(flags: flags, execute: block)
+        }
+        return try DispatchQueue.main.safeSync(execute: block)
+    }
+
+    private func setInjectedValue(_ value: Value?) {
+        atomicWrite(onMain: true) {
+            stateInjectedValue = value
+        }
+        atomicWrite {
+            injectedValue = value
         }
     }
 }

--- a/Sources/SwiftEnvironment/Environment/GlobalEnvironment.swift
+++ b/Sources/SwiftEnvironment/Environment/GlobalEnvironment.swift
@@ -85,13 +85,7 @@ public final class GlobalEnvironment<Value>: DynamicProperty, PropertyWrapperDis
             .store(in: &cancellables)
     }
     
-    /// Reads a value atomically using the property wrapper's internal queue.
-    /// 
-    /// This ensures thread-safe access to the property wrapper's state.
-    /// 
-    /// - Parameter block: A closure that reads the value.
-    /// - Returns: The result of the closure.
-    public func atomicRead<Result>(onMain: Bool = false, _ block: () throws -> Result) rethrows -> Result {
+    private func atomicRead<Result>(onMain: Bool = false, _ block: () throws -> Result) rethrows -> Result {
         return try atomicRun(onMain: onMain, block)
     }
     

--- a/Sources/SwiftEnvironment/Environment/GlobalEnvironment.swift
+++ b/Sources/SwiftEnvironment/Environment/GlobalEnvironment.swift
@@ -33,11 +33,14 @@ public final class GlobalEnvironment<Value>: DynamicProperty, PropertyWrapperDis
     private var cancellables: Set<AnyCancellable> = []
     
     @State private var lastAssignmentId: UUID?
-    @State private var injectedValue: Value?
+    @State private var injectedValueVersion: Int = 0
+
+    private var injectedValue: Value?
+
     private lazy var resolvedValue: Value = GlobalValues()[keyPath: keyPath]
-    
+
     /// The value of the property wrapper.
-    /// 
+    ///
     /// If a value has been locally injected (e.g., in a test or preview), this returns the injected value.
     /// Otherwise, it returns the value resolved from the global environment.
     public var wrappedValue: Value {
@@ -49,6 +52,9 @@ public final class GlobalEnvironment<Value>: DynamicProperty, PropertyWrapperDis
         set {
             atomicWrite {
                 injectedValue = newValue
+            }
+            DispatchQueue.main.async { [weak self] in
+                self?.injectedValueVersion &+= 1
             }
         }
     }
@@ -69,6 +75,9 @@ public final class GlobalEnvironment<Value>: DynamicProperty, PropertyWrapperDis
         atomicWrite {
             injectedValue = nil
         }
+        DispatchQueue.main.async { [weak self] in
+            self?.injectedValueVersion = 0
+        }
     }
     
     private func observeGlobalEnvironment() {
@@ -79,6 +88,7 @@ public final class GlobalEnvironment<Value>: DynamicProperty, PropertyWrapperDis
         GlobalValues.assignedResolversSubject
             .map { $0.1.id }
             .removeDuplicates()
+            .receive(on: DispatchQueue.main)
             .weakAssign(to: \.lastAssignmentId, on: self)
             .store(in: &cancellables)
     }

--- a/Sources/SwiftEnvironment/Extensions/Publisher+Extensions.swift
+++ b/Sources/SwiftEnvironment/Extensions/Publisher+Extensions.swift
@@ -8,7 +8,50 @@
 import Foundation
 import Combine
 
+// MARK: - ImmediateWhenMainScheduler
+
+/// A custom scheduler that executes immediately if already on the main thread,
+/// otherwise dispatches to the main queue.
+private final class ImmediateWhenMainScheduler: Scheduler {
+    typealias SchedulerTimeType = DispatchQueue.SchedulerTimeType
+    typealias SchedulerOptions = DispatchQueue.SchedulerOptions
+    
+    static let shared = ImmediateWhenMainScheduler()
+    
+    var now: SchedulerTimeType {
+        DispatchQueue.main.now
+    }
+    
+    var minimumTolerance: SchedulerTimeType.Stride {
+        DispatchQueue.main.minimumTolerance
+    }
+    
+    init() {}
+    
+    func schedule(options: SchedulerOptions?, _ action: @escaping () -> Void) {
+        if Thread.isMainThread {
+            action()
+        } else {
+            DispatchQueue.main.schedule(options: options, action)
+        }
+    }
+    
+    func schedule(after date: SchedulerTimeType, tolerance: SchedulerTimeType.Stride, options: SchedulerOptions?, _ action: @escaping () -> Void) {
+        DispatchQueue.main.schedule(after: date, tolerance: tolerance, options: options, action)
+    }
+    
+    func schedule(after date: SchedulerTimeType, interval: SchedulerTimeType.Stride, tolerance: SchedulerTimeType.Stride, options: SchedulerOptions?, _ action: @escaping () -> Void) -> Cancellable {
+        DispatchQueue.main.schedule(after: date, interval: interval, tolerance: tolerance, options: options, action)
+    }
+}
+
 extension Publisher where Failure == Never {
+    
+    func ensureOnMain() -> AnyPublisher<Output, Failure> {
+        receive(on: ImmediateWhenMainScheduler.shared)
+            .eraseToAnyPublisher()
+    }
+    
     /// Assigns the publisher's output to a property on an object using weak references to prevent retain cycles.
     /// 
     /// - Parameters:

--- a/Tests/SwiftEnvironmentTests/PublisherExtensionsTests.swift
+++ b/Tests/SwiftEnvironmentTests/PublisherExtensionsTests.swift
@@ -1,0 +1,51 @@
+//
+//  PublisherExtensionsTests.swift
+//  SwiftEnvironmentTests
+//
+//  Created by Nayanda Haberty on 10/03/26.
+//
+
+import XCTest
+import Combine
+@testable import SwiftEnvironment
+
+final class PublisherExtensionsTests: XCTestCase {
+
+    func test_givenMainThreadPublisher_whenEnsureOnMain_thenShouldReceiveOnMainThread() {
+        let expectation = expectation(description: "receive on main thread")
+        var isMainThread = false
+        var cancellables: Set<AnyCancellable> = []
+
+        Just(1)
+            .ensureOnMain()
+            .sink { value in
+                XCTAssertEqual(value, 1)
+                isMainThread = Thread.isMainThread
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertTrue(isMainThread)
+    }
+
+    func test_givenBackgroundThreadPublisher_whenEnsureOnMain_thenShouldReceiveOnMainThread() {
+        let expectation = expectation(description: "receive on main thread from background")
+        var isMainThread = false
+        var cancellables: Set<AnyCancellable> = []
+
+        DispatchQueue.global().async {
+            Just(1)
+                .ensureOnMain()
+                .sink { value in
+                    XCTAssertEqual(value, 1)
+                    isMainThread = Thread.isMainThread
+                    expectation.fulfill()
+                }
+                .store(in: &cancellables)
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertTrue(isMainThread)
+    }
+}


### PR DESCRIPTION
## Summary
- track local injected value updates with an explicit state version tick
- reset local injected state version when clearing injected values
- ensure global assignment updates are received on the main queue before state assignment

## Testing
- not run (not requested)