### PR TITLE
[codex] Remove Chary dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,6 @@ import CompilerPluginSupport
 var development: Bool = false
 
 let dependencies: [PackageDescription.Package.Dependency] = [
-    .package(url: "https://github.com/hainayanda/Chary.git", .upToNextMajor(from: "1.0.7")),
     .package(url: "https://github.com/swiftlang/swift-syntax.git", "509.0.0"..<"601.0.0")
 ]
 let pluginsDependencie: [PackageDescription.Package.Dependency] = [
@@ -37,7 +36,7 @@ let package = Package(
     targets: [
         .target(
             name: "SwiftEnvironment",
-            dependencies: ["Chary", "SwiftEnvironmentMacro"],
+            dependencies: ["SwiftEnvironmentMacro"],
             plugins: plugins
         ),
         .macro(

--- a/Sources/SwiftEnvironment/Concurrency/DispatchQueueExecutor.swift
+++ b/Sources/SwiftEnvironment/Concurrency/DispatchQueueExecutor.swift
@@ -1,0 +1,26 @@
+//
+//  DispatchQueueExecutor.swift
+//  SwiftEnvironment
+//
+
+import Foundation
+
+final class DispatchQueueExecutor: @unchecked Sendable {
+    private let queue: DispatchQueue
+    private let specificKey = DispatchSpecificKey<Void>()
+
+    init(_ queue: DispatchQueue) {
+        self.queue = queue
+        queue.setSpecific(key: specificKey, value: ())
+    }
+
+    func sync<Result>(
+        flags: DispatchWorkItemFlags = [],
+        execute work: () throws -> Result
+    ) rethrows -> Result {
+        if DispatchQueue.getSpecific(key: specificKey) != nil {
+            return try work()
+        }
+        return try queue.sync(flags: flags, execute: work)
+    }
+}

--- a/Sources/SwiftEnvironment/Environment/GlobalEnvironment.swift
+++ b/Sources/SwiftEnvironment/Environment/GlobalEnvironment.swift
@@ -9,7 +9,9 @@ import Foundation
 import Combine
 import SwiftUI
 
-private let accessQueue = DispatchQueue(label: "GlobalEnvironment.accessQueue", attributes: .concurrent)
+private let accessQueue = DispatchQueueExecutor(
+    DispatchQueue(label: "GlobalEnvironment.accessQueue", attributes: .concurrent)
+)
 
 /// A property wrapper that provides access to global environment values.
 /// 
@@ -95,9 +97,12 @@ public final class GlobalEnvironment<Value>: DynamicProperty, PropertyWrapperDis
     
     private func atomicRun<Result>(flags: DispatchWorkItemFlags = [], onMain: Bool = false, _ block: () throws -> Result) rethrows -> Result {
         guard onMain else {
-            return try accessQueue.safeSync(flags: flags, execute: block)
+            return try accessQueue.sync(flags: flags, execute: block)
         }
-        return try DispatchQueue.main.safeSync(execute: block)
+        if Thread.isMainThread {
+            return try block()
+        }
+        return try DispatchQueue.main.sync(execute: block)
     }
 
     private func setInjectedValue(_ value: Value?) {

--- a/Sources/SwiftEnvironment/Environment/GlobalValues.swift
+++ b/Sources/SwiftEnvironment/Environment/GlobalValues.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import Combine
-import Chary
 
 /// A struct that provides global access to environment values using dynamic member lookup.
 /// 
@@ -27,7 +26,9 @@ import Chary
 @dynamicMemberLookup
 public struct GlobalValues: @unchecked Sendable {
     
-    private static let accessQueue = DispatchQueue(label: "GlobalValues.accessQueue", attributes: .concurrent)
+    private static let accessQueue = DispatchQueueExecutor(
+        DispatchQueue(label: "GlobalValues.accessQueue", attributes: .concurrent)
+    )
     
     /// A dictionary mapping key paths to their instance resolvers.
     private static var underlyingResolvers: [PartialKeyPath<GlobalValues>: InstanceResolver] = [:]
@@ -176,13 +177,13 @@ public struct GlobalValues: @unchecked Sendable {
     /// - Parameter block: A closure that reads the value.
     /// - Returns: The result of the closure.
     public static func atomicRead<Result>(_ block: () throws -> Result) rethrows -> Result {
-        try accessQueue.safeSync {
+        try accessQueue.sync {
             try block()
         }
     }
     
     private static func atomicWrite<Result>(_ block: () throws -> Result) rethrows -> Result {
-        try accessQueue.safeSync(flags: .barrier) {
+        try accessQueue.sync(flags: .barrier) {
             try block()
         }
     }

--- a/Sources/SwiftEnvironment/InstanceResolver/OptionalTransientInstanceResolver.swift
+++ b/Sources/SwiftEnvironment/InstanceResolver/OptionalTransientInstanceResolver.swift
@@ -6,20 +6,19 @@
 //
 
 import Foundation
-import Chary
 
 struct OptionalTransientInstanceResolver<Value>: InstanceResolver {
     let id: UUID = UUID()
     private let resolver: () -> Value?
-    private let queue: DispatchQueue?
+    private let executor: DispatchQueueExecutor?
     
-    @inlinable init(queue: DispatchQueue?, resolver: @escaping () -> Value?) {
+    init(queue: DispatchQueue?, resolver: @escaping () -> Value?) {
         self.resolver = resolver
-        self.queue = queue
+        self.executor = queue.map(DispatchQueueExecutor.init)
     }
     
-    @inlinable func resolve<V>(for type: V.Type) -> V? {
-        let instance = queue?.safeSync(execute: resolver) ?? resolver()
+    func resolve<V>(for type: V.Type) -> V? {
+        let instance = executor?.sync(execute: resolver) ?? resolver()
         return instance as? V
     }
 }

--- a/Sources/SwiftEnvironment/InstanceResolver/SingletonInstanceResolver.swift
+++ b/Sources/SwiftEnvironment/InstanceResolver/SingletonInstanceResolver.swift
@@ -11,16 +11,16 @@ final class SingletonInstanceResolver<Value>: InstanceResolver {
     let id: UUID = UUID()
     private(set) var instance: Value?
     private var resolver: (() -> Value)?
-    private let queue: DispatchQueue?
+    private let executor: DispatchQueueExecutor?
     
     private let lock: NSLock = NSLock()
     
-    @inlinable init(queue: DispatchQueue?, resolver: @escaping () -> Value) {
+    init(queue: DispatchQueue?, resolver: @escaping () -> Value) {
         self.resolver = resolver
-        self.queue = queue
+        self.executor = queue.map(DispatchQueueExecutor.init)
     }
     
-    @inlinable func resolve<V>(for type: V.Type) -> V? {
+    func resolve<V>(for type: V.Type) -> V? {
         lock.lock()
         defer { lock.unlock() }
         guard let instance else {
@@ -28,7 +28,7 @@ final class SingletonInstanceResolver<Value>: InstanceResolver {
                 assertionFailure("SingletonInstanceResolver: resolver is nil before instance was created")
                 return nil
             }
-            let newInstance = queue?.safeSync(execute: resolver) ?? resolver()
+            let newInstance = executor?.sync(execute: resolver) ?? resolver()
             self.resolver = nil
             self.instance = newInstance
             return newInstance as? V

--- a/Sources/SwiftEnvironment/InstanceResolver/TransientInstanceResolver.swift
+++ b/Sources/SwiftEnvironment/InstanceResolver/TransientInstanceResolver.swift
@@ -6,20 +6,19 @@
 //
 
 import Foundation
-import Chary
 
 struct TransientInstanceResolver<Value>: InstanceResolver {
     let id: UUID = UUID()
     private let resolver: () -> Value
-    private let queue: DispatchQueue?
+    private let executor: DispatchQueueExecutor?
     
-    @inlinable init(queue: DispatchQueue?, resolver: @escaping () -> Value) {
+    init(queue: DispatchQueue?, resolver: @escaping () -> Value) {
         self.resolver = resolver
-        self.queue = queue
+        self.executor = queue.map(DispatchQueueExecutor.init)
     }
     
-    @inlinable func resolve<V>(for type: V.Type) -> V? {
-        let instance = queue?.safeSync(execute: resolver) ?? resolver()
+    func resolve<V>(for type: V.Type) -> V? {
+        let instance = executor?.sync(execute: resolver) ?? resolver()
         return instance as? V
     }
 }

--- a/Sources/SwiftEnvironment/InstanceResolver/WeakInstanceResolver.swift
+++ b/Sources/SwiftEnvironment/InstanceResolver/WeakInstanceResolver.swift
@@ -6,22 +6,21 @@
 //
 
 import Foundation
-import Chary
 
 final class WeakInstanceResolver<Value>: InstanceResolver {
     let id: UUID = UUID()
     private(set) weak var instance: AnyObject?
     private let resolver: () -> Value
-    private let queue: DispatchQueue?
+    private let executor: DispatchQueueExecutor?
     
     private let lock: NSLock = NSLock()
     
-    @inlinable init(queue: DispatchQueue?, resolver: @escaping () -> Value) {
+    init(queue: DispatchQueue?, resolver: @escaping () -> Value) {
         self.resolver = resolver
-        self.queue = queue
+        self.executor = queue.map(DispatchQueueExecutor.init)
     }
     
-    @inlinable func resolve<V>(for type: V.Type) -> V? {
+    func resolve<V>(for type: V.Type) -> V? {
         lock.lock()
         defer { lock.unlock() }
         
@@ -29,7 +28,7 @@ final class WeakInstanceResolver<Value>: InstanceResolver {
             return instance as? V
         }
         
-        let newInstance = queue?.safeSync(execute: resolver) ?? resolver()
+        let newInstance = executor?.sync(execute: resolver) ?? resolver()
         let isClassInstance = Swift.type(of: newInstance) is AnyClass
         if !isClassInstance {
             assertionFailure("WeakInstanceResolver expects a class instance. Use a class-bound protocol or ensure the resolver returns a reference type.")

--- a/Tests/SwiftEnvironmentTests/DispatchQueueExecutorTests.swift
+++ b/Tests/SwiftEnvironmentTests/DispatchQueueExecutorTests.swift
@@ -1,0 +1,24 @@
+//
+//  DispatchQueueExecutorTests.swift
+//  SwiftEnvironmentTests
+//
+
+import XCTest
+@testable import SwiftEnvironment
+
+final class DispatchQueueExecutorTests: XCTestCase {
+
+    func test_givenCurrentQueue_whenSync_shouldExecuteWithoutDeadlock() {
+        let queue = DispatchQueue(label: "DispatchQueueExecutorTests.serialQueue")
+        let executor = DispatchQueueExecutor(queue)
+        let completed = expectation(description: "Nested sync completed")
+
+        queue.async {
+            let value = executor.sync { "resolved" }
+            XCTAssertEqual(value, "resolved")
+            completed.fulfill()
+        }
+
+        wait(for: [completed], timeout: 1)
+    }
+}


### PR DESCRIPTION
## Problem

Chary is deprecated and its `safeSync` helper is no longer a suitable dependency for SwiftEnvironment.

## Solution

- Remove Chary from the SwiftPM manifest and library target.
- Add an internal `DispatchQueueExecutor` that uses queue-specific context to avoid nested synchronous dispatch deadlocks.
- Update global environment access and instance resolvers to use the internal executor.
- Handle main-thread execution directly in `GlobalEnvironment`.
- Add a regression test covering nested synchronization on the configured queue.

## Impact

Consumers no longer transitively depend on Chary. Existing resolver queue behavior remains intact while nested queue access stays deadlock-safe.

## Validation

- `xcrun swift build`
- `xcrun swift test` (20 tests, 0 failures)
- `git diff --check`
- Confirmed `swift package show-dependencies` only lists `swift-syntax`